### PR TITLE
customer support fix

### DIFF
--- a/Components/Footer.tsx
+++ b/Components/Footer.tsx
@@ -76,7 +76,7 @@ const Footer = () => {
                 { href: '/contacts', label: 'Contact Us' },
                 { href: '/about', label: 'About Us' },
                 { href: '/location', label: 'Our Locations' },
-                { href: 'mailto:support@staycationhaven.ph', label: 'Customer Support', isExternal: true },
+                { href: 'https://mail.google.com/mail/?view=cm&fs=1&to=support@staycationhaven.ph',label: 'Customer Support',isExternal: true},
                 { href: '/rooms', label: 'Browse Havens' },
                 { href: '/help-center', label: 'Help Center' }
               ].map((item) => (
@@ -84,6 +84,8 @@ const Footer = () => {
                   {item.isExternal ? (
                     <a
                       href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
                       className={`text-sm hover:text-brand-primary transition-colors flex items-center gap-1.5 group ${pathname === item.href ? 'text-brand-primary font-semibold' : 'text-gray-700 dark:text-gray-300'}`}
                     >
                       <ChevronRight className="w-3 h-3 group-hover:translate-x-1 transition-transform flex-shrink-0" />


### PR DESCRIPTION
// NOTE:
// This is not a bug.
// The original `mailto:` link triggered an app selection popup because
// no default mail client was configured on some devices.
// To ensure a consistent user experience, we now redirect users
// directly to a web-based email composer (Gmail).