### PR TITLE
Fix payment approval and activity logging errors

### DIFF
--- a/Components/admin/Csr/PaymentPage.tsx
+++ b/Components/admin/Csr/PaymentPage.tsx
@@ -155,7 +155,7 @@ export default function PaymentPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             employee_id: employeeId,
-            activity_type: activityType,
+            action_type: activityType,
             description,
             entity_type: entityType ?? null,
             entity_id: entityId ?? null,


### PR DESCRIPTION
Fixed a bug where payment approvals failed with "prevAmountPaid is not defined" by adding the missing `amount_paid` column to the SQL query. Also corrected activity logging API field from `activity_type` to `action_type` to match endpoint requirements. Removed unused variables.

Issue: 
<img width="2158" height="1303" alt="image" src="https://github.com/user-attachments/assets/3573d6bf-5aa1-4385-bee8-0585cbecdd04" />
<img width="1180" height="850" alt="image" src="https://github.com/user-attachments/assets/70903326-fb97-4535-b28e-63f49a005b87" />
