### PR TITLE
Fix NaN display in average ratings

### DIFF
--- a/Components/admin/Cleaners/ProfilePage.tsx
+++ b/Components/admin/Cleaners/ProfilePage.tsx
@@ -462,7 +462,9 @@ export default function ProfilePage({ cleanerData }: ProfilePageProps) {
     },
     {
         label: "Average Rating",
-        value: performanceStats.averageRating?.toFixed(1) || "0.0",
+        value: (typeof performanceStats.averageRating === 'number' && !isNaN(performanceStats.averageRating)) 
+          ? performanceStats.averageRating.toFixed(1) 
+          : "0.0",
         change: performanceStats.ratingChange || "0",
         color: "bg-yellow-500",
         icon: Star,

--- a/Components/admin/Owners/DashboardPage.tsx
+++ b/Components/admin/Owners/DashboardPage.tsx
@@ -179,9 +179,13 @@ const DashboardPage = ({
   // Get real revenue from analytics
   const totalRevenue = Number(analyticsData?.total_revenue || 0);
 
-  // Calculate average rating
-  const averageRating = reviews.length > 0 
-    ? (reviews.reduce((sum: number, review: any) => sum + (review.overall_rating || 0), 0) / reviews.length).toFixed(1)
+  // Calculate average rating - handle NaN and null values properly
+  const validRatings = reviews
+    .map((review: any) => review.overall_rating)
+    .filter((rating: any) => typeof rating === 'number' && !isNaN(rating));
+  
+  const averageRating = validRatings.length > 0
+    ? (validRatings.reduce((sum: number, rating: number) => sum + rating, 0) / validRatings.length).toFixed(1)
     : '0.0';
 
   // Calculate today's tasks


### PR DESCRIPTION
- Filter out invalid ratings (NaN, non-numbers) in Owners Dashboard
- Add validation for average rating display in Cleaners Profile
- Prevent NaN from showing in UI while maintaining 0.0 display